### PR TITLE
Auto growth

### DIFF
--- a/docs/DatabaseChecks.md
+++ b/docs/DatabaseChecks.md
@@ -46,3 +46,6 @@ Reports filegroups that are not set to auto-grow. You can whitelist fixed size f
         "AdventureWorks2016CTP3_mod"
         ,"templog"]
 ```
+
+## Auto-growth & at-risk Filegroups
+Filegroups that are permitted to auto-grow should have enough space to do so. `Get-AutoGrowthRisks` reports filegroups that may run out of space and fail to complete the next autogrowth. No whitelist configuration is provided for this check. Set growth to `0` if you wish to disallow further growth actions.   

--- a/docs/DatabaseChecks.md
+++ b/docs/DatabaseChecks.md
@@ -37,3 +37,12 @@ If the config value is set to false the check will be skipped.
 ```json
 "CheckForOversizedIndexes": true
 ```
+
+## Fixed-Size Filegroups  
+Reports filegroups that are not set to auto-grow. You can whitelist fixed size filegroups by adding the name to the config array
+
+```json
+"ZeroAutoGrowthWhitelistFGs":[
+        "AdventureWorks2016CTP3_mod"
+        ,"templog"]
+```

--- a/examples/SingleCheck/localhost.config.json
+++ b/examples/SingleCheck/localhost.config.json
@@ -1,16 +1,16 @@
 {
-    "ServerInstance":"localhost",
-    "SpConfig": {
-        "MaxDegreeOfParallelism":0,
-        "XpCmdShellEnabled":0,
-        "ShowAdvancedOptions":0
-    },
-    "NumErrorLogs": 14,
-    "TraceFlags":[3226,7412],
-    "MustHaveDDLTrigger": "TR_DoesNotExist",
-    "CheckForOversizedIndexes": true,
-    "CheckForPercentageGrowthLogFiles": true,
-    "MaxTLogAutoGrowthInKB": 900000,
-    "MaxDaysAllowedSinceLastGoodCheckDb":7,
-    "ZeroAutoGrowthWhitelistDBs":["AdventureWorks","tempdb"]
+    "ServerInstance":"localhost"
+    ,"SpConfig": {
+        "MaxDegreeOfParallelism":0
+        ,"XpCmdShellEnabled":0
+        ,"ShowAdvancedOptions":0
+    }
+    ,"NumErrorLogs": 14
+    ,"TraceFlags":[3226,7412]
+    ,"MustHaveDDLTrigger": "TR_DoesNotExist"
+    ,"CheckForOversizedIndexes": true
+    ,"CheckForPercentageGrowthLogFiles": true
+    ,"MaxTLogAutoGrowthInKB": 900000
+    ,"MaxDaysAllowedSinceLastGoodCheckDb":7
+    ,"ZeroAutoGrowthWhitelistDBs":["AdventureWorks","tempdb"]
 }

--- a/examples/SingleCheck/localhost.config.json
+++ b/examples/SingleCheck/localhost.config.json
@@ -12,5 +12,8 @@
     ,"CheckForPercentageGrowthLogFiles": true
     ,"MaxTLogAutoGrowthInKB": 900000
     ,"MaxDaysAllowedSinceLastGoodCheckDb":7
-    ,"ZeroAutoGrowthWhitelistDBs":["AdventureWorks","tempdb"]
+    ,"ZeroAutoGrowthWhitelistFGs":[
+        "AdventureWorks2016CTP3_mod"
+        ,"templog"
+    ]
 }

--- a/examples/SingleCheck/localhost.config.json
+++ b/examples/SingleCheck/localhost.config.json
@@ -11,5 +11,6 @@
     "CheckForOversizedIndexes": true,
     "CheckForPercentageGrowthLogFiles": true,
     "MaxTLogAutoGrowthInKB": 900000,
-    "MaxDaysAllowedSinceLastGoodCheckDb":7
+    "MaxDaysAllowedSinceLastGoodCheckDb":7,
+    "ZeroAutoGrowthWhitelistDBs":["AdventureWorks","tempdb"]
 }

--- a/src/SQLChecks/Get-AutoGrowthRisks.ps1
+++ b/src/SQLChecks/Get-AutoGrowthRisks.ps1
@@ -1,0 +1,15 @@
+﻿Function Get-AutoGrowthRisks {
+    [cmdletbinding()]Param(
+         [parameter(Mandatory=$true)][string]$ServerInstance
+        ,$WhitelistFilegroups # optional array or comma-delim string
+    )
+
+    $WLFGNames=@()
+    if($WhitelistFilegroups -ne $null){$WLFGNames+=$WhitelistFilegroups.Split(",")}
+
+    $query=(gc $PSScriptRoot/../SQLScripts/auto-growth-will-fail-for-max_size.sql -Raw)
+    
+    (Invoke-Sqlcmd -ServerInstance $ServerInstance -Database master -Query $query) | where {
+        $WLFGNames -notcontains $_.fName
+    } | Select srvr,dbName,fName,growthMb,curSizeMb,maxSizeMb,nextGrowthSizeMb,cmd | ft
+}

--- a/src/SQLChecks/Get-AutoGrowthRisks.ps1
+++ b/src/SQLChecks/Get-AutoGrowthRisks.ps1
@@ -11,5 +11,5 @@
     
     (Invoke-Sqlcmd -ServerInstance $ServerInstance -Database master -Query $query) | where {
         $WLFGNames -notcontains $_.fName
-    } | Select srvr,dbName,fName,growthMb,curSizeMb,maxSizeMb,nextGrowthSizeMb,cmd | ft
+    } | Select srvr,db_name,f_name,growth_mb,cur_size_mb,max_size_mb,next_growth_size_mb,grow_file_cmd | ft
 }

--- a/src/SQLChecks/Get-DbsWithoutAutogrow.ps1
+++ b/src/SQLChecks/Get-DbsWithoutAutogrow.ps1
@@ -1,0 +1,16 @@
+﻿function Get-DbsWithoutAutogrow {
+    [cmdletbinding()]Param(
+         [parameter(Mandatory=$true)][string]$ServerInstance
+        ,$excludeDbs # optional array or comma-delim string
+    )
+
+    $excludeDb=@()
+    if($excludeDbs -ne $null){$excludeDb+=$excludeDbs.Split(",")}
+
+    $query=(gc $PSScriptRoot/../SQLScripts/auto-growth-zero.sql -Raw)
+
+    (Invoke-Sqlcmd -ServerInstance $ServerInstance -Database master -Query $query) | where {
+        $excludeDb -notcontains $_.dbName
+    }
+}
+

--- a/src/SQLChecks/Get-FixedSizeFileGroups.ps1
+++ b/src/SQLChecks/Get-FixedSizeFileGroups.ps1
@@ -10,7 +10,6 @@
     $query=(gc $PSScriptRoot/../SQLScripts/auto-growth-zero.sql -Raw)
 
     (Invoke-Sqlcmd -ServerInstance $ServerInstance -Database master -Query $query) | where {
-        $WLFGNames -notcontains $_.fName
-    }
+        $WLFGNames -notcontains $_.f_name
+    } | Select db_name,f_name,type_desc,state_desc,size_mb,f_path | ft
 }
-

--- a/src/SQLChecks/Get-FixedSizeFileGroups.ps1
+++ b/src/SQLChecks/Get-FixedSizeFileGroups.ps1
@@ -1,16 +1,16 @@
-﻿function Get-DbsWithoutAutogrow {
+﻿function Get-FixedSizeFileGroups {
     [cmdletbinding()]Param(
          [parameter(Mandatory=$true)][string]$ServerInstance
-        ,$excludeDbs # optional array or comma-delim string
+        ,$WhitelistFilegroups # optional array or comma-delim string
     )
 
-    $excludeDb=@()
-    if($excludeDbs -ne $null){$excludeDb+=$excludeDbs.Split(",")}
+    $WLFGNames=@()
+    if($WhitelistFilegroups -ne $null){$WLFGNames+=$WhitelistFilegroups.Split(",")}
 
     $query=(gc $PSScriptRoot/../SQLScripts/auto-growth-zero.sql -Raw)
 
     (Invoke-Sqlcmd -ServerInstance $ServerInstance -Database master -Query $query) | where {
-        $excludeDb -notcontains $_.dbName
+        $WLFGNames -notcontains $_.fName
     }
 }
 

--- a/src/SQLChecks/SQLChecks.psm1
+++ b/src/SQLChecks/SQLChecks.psm1
@@ -7,3 +7,4 @@
 . $PSScriptRoot/Get-DatabasesOverMaxDataFileSpaceUsed.ps1
 . $PSScriptRoot/Get-DbsWithoutGoodCheckDb.ps1
 . $PSScriptRoot/Get-DuplicateIndexes.ps1
+. $PSScriptRoot/Get-DbsWithoutAutogrow.ps1

--- a/src/SQLChecks/SQLChecks.psm1
+++ b/src/SQLChecks/SQLChecks.psm1
@@ -8,3 +8,4 @@
 . $PSScriptRoot/Get-DbsWithoutGoodCheckDb.ps1
 . $PSScriptRoot/Get-DuplicateIndexes.ps1
 . $PSScriptRoot/Get-FixedSizeFileGroups.ps1
+. $PSScriptRoot/Get-AutoGrowthRisks.ps1

--- a/src/SQLChecks/SQLChecks.psm1
+++ b/src/SQLChecks/SQLChecks.psm1
@@ -7,4 +7,4 @@
 . $PSScriptRoot/Get-DatabasesOverMaxDataFileSpaceUsed.ps1
 . $PSScriptRoot/Get-DbsWithoutGoodCheckDb.ps1
 . $PSScriptRoot/Get-DuplicateIndexes.ps1
-. $PSScriptRoot/Get-DbsWithoutAutogrow.ps1
+. $PSScriptRoot/Get-FixedSizeFileGroups.ps1

--- a/src/SQLScripts/auto-growth-will-fail-for-max_size.sql
+++ b/src/SQLScripts/auto-growth-will-fail-for-max_size.sql
@@ -7,29 +7,29 @@
           ,state_desc
           ,growth
           ,is_percent_growth
-          ,growthMb=
+          ,growth_mb=
                case is_percent_growth 
                    when 1 then (growth/100.)*(try_cast(size as bigint)*8192.)/power(1024,2) 
                    else (try_cast(growth as bigint)*8192.)/power(1024,2) 
                end
-          ,sizeMb=(try_cast(size as bigint)*8192.)/power(1024,2) 
-          ,maxSizeMb=(try_cast(nullif(max_size,-1) as bigint)*8192.)/power(1024,2) 
-          ,dbName=db_name(database_id)
-          ,fName=[name]
-          ,fPath=physical_name
+          ,size_mb=(try_cast(size as bigint)*8192.)/power(1024,2) 
+          ,max_size_mb=(try_cast(nullif(max_size,-1) as bigint)*8192.)/power(1024,2) 
+          ,[db_name]=db_name(database_id)
+          ,f_name=[name]
+          ,f_path=physical_name
     from sys.master_files mf
     where max_size <> -1
 )
 select @@servername as srvr
-      ,dbName
-      ,fName
-      ,growthMb=try_convert(float,growthMb)
+      ,[db_name]
+      ,f_name
+      ,growth_mb=try_convert(float,growth_mb)
       ,is_percent_growth
-      ,curSizeMb=try_convert(float,sizeMb)
-      ,maxSizeMb=try_convert(float,maxSizeMb)
-      ,nextGrowthSizeMb=try_convert(float,sizeMb+growthMb)
-      ,cmd='alter database ['+dbName+'] modify file (name=N'''+fName+''',maxsize='+try_cast(ceiling(sizeMb+growthMb+1) as varchar)+'mb);'
-      ,fPath
+      ,cur_size_mb=try_convert(float,size_mb)
+      ,max_size_mb=try_convert(float,max_size_mb)
+      ,next_growth_size_mb=try_convert(float,size_mb+growth_mb)
+      ,grow_file_cmd='alter database ['+[db_name]+'] modify file (name=N'''+f_name+''',maxsize='+try_cast(ceiling(size_mb+growth_mb+1) as varchar)+'mb);'
+      ,f_path
       ,database_id
       ,[file_id]
       ,[type]
@@ -37,4 +37,4 @@ select @@servername as srvr
       ,[state]
       ,state_desc
 from fileGrowth fg
-where (sizeMb+growthMb)>maxSizeMb;
+where (size_mb+growth_mb)>max_size_mb;

--- a/src/SQLScripts/auto-growth-will-fail-for-max_size.sql
+++ b/src/SQLScripts/auto-growth-will-fail-for-max_size.sql
@@ -1,0 +1,40 @@
+;with fileGrowth as (
+    select database_id
+          ,[file_id]
+          ,[type]
+          ,[type_desc]
+          ,[state]
+          ,state_desc
+          ,growth
+          ,is_percent_growth
+          ,growthMb=
+               case is_percent_growth 
+                   when 1 then (growth/100.)*(try_cast(size as bigint)*8192.)/power(1024,2) 
+                   else (try_cast(growth as bigint)*8192.)/power(1024,2) 
+               end
+          ,sizeMb=(try_cast(size as bigint)*8192.)/power(1024,2) 
+          ,maxSizeMb=(try_cast(nullif(max_size,-1) as bigint)*8192.)/power(1024,2) 
+          ,dbName=db_name(database_id)
+          ,fName=[name]
+          ,fPath=physical_name
+    from sys.master_files mf
+    where max_size <> -1
+)
+select @@servername as srvr
+      ,dbName
+      ,fName
+      ,growthMb=try_convert(float,growthMb)
+      ,is_percent_growth
+      ,curSizeMb=try_convert(float,sizeMb)
+      ,maxSizeMb=try_convert(float,maxSizeMb)
+      ,nextGrowthSizeMb=try_convert(float,sizeMb+growthMb)
+      ,cmd='alter database ['+dbName+'] modify file (name=N'''+fName+''',maxsize='+try_cast(ceiling(sizeMb+growthMb+1) as varchar)+'mb);'
+      ,fPath
+      ,database_id
+      ,[file_id]
+      ,[type]
+      ,[type_desc]
+      ,[state]
+      ,state_desc
+from fileGrowth fg
+where (sizeMb+growthMb)>maxSizeMb;

--- a/src/SQLScripts/auto-growth-zero.sql
+++ b/src/SQLScripts/auto-growth-zero.sql
@@ -1,0 +1,15 @@
+select mf.database_id
+      ,mf.[file_id]
+      ,mf.[type]
+      ,mf.[type_desc]
+      ,mf.[state]
+      ,mf.state_desc
+      ,mf.growth
+      ,mf.is_percent_growth
+      ,sizeMb=(try_cast(mf.size as bigint)*8000.)/power(1024,2) 
+      ,mf.max_size
+      ,dbName=db_name(mf.database_id)
+      ,fName=mf.[name]
+      ,fPath=mf.physical_name
+from sys.master_files mf
+where mf.growth = 0;

--- a/src/SQLScripts/auto-growth-zero.sql
+++ b/src/SQLScripts/auto-growth-zero.sql
@@ -1,15 +1,14 @@
-select mf.database_id
-      ,mf.[file_id]
-      ,mf.[type]
-      ,mf.[type_desc]
-      ,mf.[state]
-      ,mf.state_desc
-      ,mf.growth
-      ,mf.is_percent_growth
-      ,sizeMb=(try_cast(mf.size as bigint)*8192.)/power(1024,2) 
-      ,mf.max_size
-      ,dbName=db_name(mf.database_id)
-      ,fName=mf.[name]
-      ,fPath=mf.physical_name
-from sys.master_files mf
-where mf.growth = 0;
+select database_id
+      ,[file_id]
+      ,[type]
+      ,[type_desc]
+      ,[state]
+      ,state_desc
+      ,growth
+      ,size_mb=try_convert(float,(try_cast(size as bigint)*8192.)/power(1024,2)) 
+      ,max_size
+      ,[db_name]=db_name(database_id)
+      ,f_name=[name]
+      ,f_path=physical_name
+from sys.master_files 
+where growth = 0;

--- a/src/SQLScripts/auto-growth-zero.sql
+++ b/src/SQLScripts/auto-growth-zero.sql
@@ -6,7 +6,7 @@ select mf.database_id
       ,mf.state_desc
       ,mf.growth
       ,mf.is_percent_growth
-      ,sizeMb=(try_cast(mf.size as bigint)*8000.)/power(1024,2) 
+      ,sizeMb=(try_cast(mf.size as bigint)*8192.)/power(1024,2) 
       ,mf.max_size
       ,dbName=db_name(mf.database_id)
       ,fName=mf.[name]

--- a/tests/Databases.tests.ps1
+++ b/tests/Databases.tests.ps1
@@ -69,10 +69,10 @@ Describe "SQL Server Databases" {
             }
 
             It "$serverInstance has no zero-autoGrowth FileGroups outside whitelist"{
-                $ZeroAutoGrowthWhitelistDBs=$config.ZeroAutoGrowthWhitelistDBs
+                $ZeroAutoGrowthWhitelistFGs=$config.ZeroAutoGrowthWhitelistFGs
             # missing config value does NOT result in inconclusive test.
             # if no config value, check ALL filegroups and fail on zero-autogrowth
-                @(Get-DbsWithoutAutogrow -ServerInstance $serverInstance -excludeDbs $ZeroAutoGrowthWhitelistDBs) | Should Be 0
+                @(Get-FixedSizeFileGroups -ServerInstance $serverInstance -WhitelistFilegroups $ZeroAutoGrowthWhitelistFGs) | Should Be 0
             }
         }
     }

--- a/tests/Databases.tests.ps1
+++ b/tests/Databases.tests.ps1
@@ -72,7 +72,7 @@ Describe "SQL Server Databases" {
                 $ZeroAutoGrowthWhitelistFGs=$config.ZeroAutoGrowthWhitelistFGs
             # missing config value does NOT result in inconclusive test.
             # if no config value, check ALL filegroups and fail on zero-autogrowth
-                @(Get-FixedSizeFileGroups -ServerInstance $serverInstance -WhitelistFilegroups $ZeroAutoGrowthWhitelistFGs) | Should Be 0
+                @(Get-FixedSizeFileGroups -ServerInstance $serverInstance -WhitelistFilegroups $ZeroAutoGrowthWhitelistFGs).Count | Should Be 0
             }
         }
     }

--- a/tests/Databases.tests.ps1
+++ b/tests/Databases.tests.ps1
@@ -74,6 +74,11 @@ Describe "SQL Server Databases" {
             # if no config value, check ALL filegroups and fail on zero-autogrowth
                 @(Get-FixedSizeFileGroups -ServerInstance $serverInstance -WhitelistFilegroups $ZeroAutoGrowthWhitelistFGs).Count | Should Be 0
             }
+
+            It "$serverInstance - all size-governed filegroups have sufficent space for their next growth" {
+            # no whitelist set up for this one
+                @(Get-AutoGrowthRisks -ServerInstance $serverInstance ).Count | Should Be 0
+            }
         }
     }
 }

--- a/tests/Databases.tests.ps1
+++ b/tests/Databases.tests.ps1
@@ -67,6 +67,13 @@ Describe "SQL Server Databases" {
                 }
                 @(Get-DuplicateIndexes -ServerInstance $serverInstance -ExcludeDatabase $ExcludeDatabaseStr -ExcludeIndex $ExcludeIndexStr).Count | Should Be 0
             }
+
+            It "$serverInstance has no zero-autoGrowth FileGroups outside whitelist"{
+                $ZeroAutoGrowthWhitelistDBs=$config.ZeroAutoGrowthWhitelistDBs
+            # missing config value does NOT result in inconclusive test.
+            # if no config value, check ALL filegroups and fail on zero-autogrowth
+                @(Get-DbsWithoutAutogrow -ServerInstance $serverInstance -excludeDbs $ZeroAutoGrowthWhitelistDBs) | Should Be 0
+            }
         }
     }
 }


### PR DESCRIPTION
* Check for healthy size configuration of filegroups. 
* Whitelist fixed-size filegroups. 
* Check that FGs permitted to auto-grow have space to do so
* **DOES NOT CHECK** the underlying filesystem to check available drive space